### PR TITLE
fix parseTable - strip ANSI codes from stdout

### DIFF
--- a/src/GcloudBase.ts
+++ b/src/GcloudBase.ts
@@ -2,7 +2,7 @@ import Debug from "debug";
 import YAML from "yaml";
 import {IProjectOptions} from "./GcloudSdk";
 import {GcloudCommandHelper} from "./helpers/GcloudCommandHelper";
-import {camelToDotCapitalize, camelToSnakeCapitalize, camelToSnakeCapitalizeWithoutUnderscore} from "./utils";
+import {camelToDotCapitalize, camelToSnakeCapitalize, camelToSnakeCapitalizeWithoutUnderscore, stripAnsi} from "./utils";
 
 const debug = Debug("gcloud");
 const sdkPath = process.env.GCP_SDK_PATH || "gcloud";
@@ -40,7 +40,7 @@ export class GcloudBase {
         helper.addParams(params);
         helper.addPosParams(postParams);
         const result = await helper.exec();
-        return result.stdout || result.stderr;
+        return stripAnsi(result.stdout || result.stderr);
     }
 
     protected _parseYaml(yaml: string) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -18,3 +18,7 @@ export function camelToSnakeCapitalizeWithoutUnderscore(value: string) {
 export function escapeQuotes(value: string) {
     return value.replace(/"/g, "\\\"");
 }
+
+export function stripAnsi(value: string) {
+    return value.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '');
+}


### PR DESCRIPTION
Running `npm run test:run` resulted in the following:

```
runRevisionList [
  {
    revision: '2m✔\x1B[39;0m  managed',
    active: '-00001-q',
    service: 'em  yes',
    deployed: 'managed  2021-08-25 16',
    deployedBy: ':36:01 UTC  service@my-project.iam.gserviceaccount.com'
  }
]
runServiceList [
  {
    service: '2m✔\x1B[39;0',
    region: 'm  managed',
    url: 'asia-east1  https://managed-hdpnwa5lsq-de',
    lastDeployedBy: '.a.run.app  service@my-project.iam.gservicea',
    lastDeployedAt: 'ccount.com  2021-08-25T16:36:12.023401Z'
  }
]
```

---

After stripping ANSI codes from stdout:
```
runRevisionList [
  {
    revision: 'managed-00002-vop',
    active: 'yes',
    service: 'managed',
    deployed: '2021-08-25 16:39:41 UTC',
    deployedBy: 'service@my-project.iam.gserviceaccount.com'
  },
  {
    revision: 'managed-00001-qem',
    active: '',
    service: 'managed',
    deployed: '2021-08-25 16:36:01 UTC',
    deployedBy: 'service@my-project.iam.gserviceaccount.com'
  }
]
runServiceList [
  {
    service: 'managed',
    region: 'asia-east1',
    url: 'https://managed-hdpnwa5lsq-de.a.run.app',
    lastDeployedBy: 'service@my-project.iam.gserviceaccount.com',
    lastDeployedAt: '2021-08-25T16:39:54.626016Z'
  }
]
```